### PR TITLE
Fix plan output for TF 0.14 and up

### DIFF
--- a/src/terraform_plan.sh
+++ b/src/terraform_plan.sh
@@ -19,8 +19,7 @@ function terraformPlan {
   if echo "${planOutput}" | egrep '^An execution plan has been generated' &> /dev/null; then
       planOutput=$(echo "${planOutput}" | sed '1,/An execution plan has been generated/d')
   fi
-  planOutput=$(echo "${planOutput}" | sed -r -e 's/^  \+/\+/g' | sed -r -e 's/^  ~/~/g' | sed -r -e 's/^  -/-/g')
-  planOutput=$(echo "${planOutput}" | sed -r -e '/-{72}/q;p')
+  planOutput=$(echo "${planOutput}" | sed -r -e 's/^  \+/\+/g' | sed -r -e 's/^  ~/~/g' | sed -r -e 's/^  -/-/g' | sed -r -e '/^-------/Q')
 
   # If output is longer than max length (65536 characters), keep last part
   planOutput=$(echo "${planOutput}" | tail -c 65000 )

--- a/src/terraform_plan.sh
+++ b/src/terraform_plan.sh
@@ -20,7 +20,6 @@ function terraformPlan {
       planOutput=$(echo "${planOutput}" | sed '1,/An execution plan has been generated/d')
   fi
   planOutput=$(echo "${planOutput}" | sed -r -e 's/^  \+/\+/g' | sed -r -e 's/^  ~/~/g' | sed -r -e 's/^  -/-/g')
-  planOutput=$(echo "${planOutput}" | sed -r -e '/^-------/Q')
 
   # If output is longer than max length (65536 characters), keep last part
   planOutput=$(echo "${planOutput}" | tail -c 65000 )

--- a/src/terraform_plan.sh
+++ b/src/terraform_plan.sh
@@ -16,10 +16,11 @@ function terraformPlan {
   echo "${planOutput}" > "${planOutputFile}"
 
   # Clean up the output
-  if echo "${planOutput}" | egrep '^-{72}$' &> /dev/null; then
-        planOutput=$(echo "${planOutput}" | sed -n -r '/-{72}/,/-{72}/{ /-{72}/d; p }')
+  if echo "${planOutput}" | egrep '^An execution plan has been generated' &> /dev/null; then
+      planOutput=$(echo "${planOutput}" | sed '1,/An execution plan has been generated/d')
   fi
   planOutput=$(echo "${planOutput}" | sed -r -e 's/^  \+/\+/g' | sed -r -e 's/^  ~/~/g' | sed -r -e 's/^  -/-/g')
+  planOutput=$(echo "${planOutput}" | sed -r -e '/-{72}/q;p')
 
   # If output is longer than max length (65536 characters), keep last part
   planOutput=$(echo "${planOutput}" | tail -c 65000 )

--- a/src/terraform_plan.sh
+++ b/src/terraform_plan.sh
@@ -19,7 +19,8 @@ function terraformPlan {
   if echo "${planOutput}" | egrep '^An execution plan has been generated' &> /dev/null; then
       planOutput=$(echo "${planOutput}" | sed '1,/An execution plan has been generated/d')
   fi
-  planOutput=$(echo "${planOutput}" | sed -r -e 's/^  \+/\+/g' | sed -r -e 's/^  ~/~/g' | sed -r -e 's/^  -/-/g' | sed -r -e '/^-------/Q')
+  planOutput=$(echo "${planOutput}" | sed -r -e 's/^  \+/\+/g' | sed -r -e 's/^  ~/~/g' | sed -r -e 's/^  -/-/g')
+  planOutput=$(echo "${planOutput}" | sed -r -e '/^-------/Q')
 
   # If output is longer than max length (65536 characters), keep last part
   planOutput=$(echo "${planOutput}" | tail -c 65000 )


### PR DESCRIPTION
This fixes the output of plans not being inserted as a comment into a PR with Terraform 0.14 and up.  The root problem is that the parsing here was looking for a 

`------------------------------------------------------------------------`

AFTER the list of the resources.  This is no longer there with TF 0.14 :awk:

So I just made it generic to work with 0.13 and 0.14 by looking for the actual line that precedes the plan output.

A lot of this is pants but we have a [TODO](https://3.basecamp.com/3826093/buckets/18920269/todos/3057723181) to move to the newer Hashicorp official actions (they abandoned these ones just after I'd finished integrating them ✊ )