### PR TITLE
fix plan.txt path

### DIFF
--- a/src/terraform_plan.sh
+++ b/src/terraform_plan.sh
@@ -7,7 +7,7 @@ function terraformPlan {
   planExitCode=${?}
   planHasChanges=false
   planCommentStatus="Failed"
-  planOutputFile="${tfWorkingDir}/plan.txt"
+  planOutputFile="plan.txt"
   touch "${planOutputFile}"
   echo "::set-output name=tf_actions_plan_output_file::${planOutputFile}"
 


### PR DESCRIPTION
I was making use of the TF working dir (`tf_actions_working_dir) and the plan.txt uploading was broken.  Turns out when the plan function is called, the script is already in the working directory so we shouldn't prepend it again.

It was working because it the working dir was always in the root directory which was == to `.`

https://github.com/rewindio/terraform-github-actions/blob/6b80b070166e479509fb0dde0779a3d3d1bc01e5/src/main.sh#L130

![image](https://user-images.githubusercontent.com/32844597/128252259-b87d2411-ffa8-4210-8a8a-4e18ec68f451.png)

![image](https://user-images.githubusercontent.com/32844597/128252359-db6e73aa-2233-4c98-b017-6ce6bf459c3b.png)

After these changes it works as expected

